### PR TITLE
Fix server start error

### DIFF
--- a/ClipSyncWindowsFormApplication/App.config
+++ b/ClipSyncWindowsFormApplication/App.config
@@ -17,6 +17,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <runtime>
+  <loadFromRemoteSources enabled="true"/>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />


### PR DESCRIPTION
Fix "An attempt was made to load an assembly from a network location which would have caused the assembly to be sandboxed in previous versions of the .NET Framework"

Resolves #13